### PR TITLE
chore: auto lint pre-commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npm run lint

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-npm run lint
+pnpm run lint

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "lint": "eslint . --ignore-path .gitignore --ext .ts",
     "lint:fix": "npm run lint -- --fix",
     "start": "node --experimental-specifier-resolution=node dist/main",
-    "start:dev": "rimraf ./dist && npm run compile && node --experimental-specifier-resolution=node --no-warnings dist/main"
+    "start:dev": "rimraf ./dist && npm run compile && node --experimental-specifier-resolution=node --no-warnings dist/main",
+    "prepare": "husky install"
   },
   "repository": {
     "type": "git",
@@ -63,6 +64,7 @@
     "@typescript-eslint/eslint-plugin": "^5.53.0",
     "@typescript-eslint/parser": "^5.53.0",
     "eslint": "^8.34.0",
+    "husky": "^8.0.3",
     "rimraf": "^4.4.0",
     "typescript": "^4.7.4"
   },
@@ -79,7 +81,7 @@
     "moment": "^2.29.4",
     "pino-pretty": "^9.4.0",
     "pretty-ms": "^8.0.0",
-    "tslib": "^2.5.0",
-    "skia-canvas": "^1.0.1"
+    "skia-canvas": "^1.0.1",
+    "tslib": "^2.5.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,7 @@ specifiers:
   discord.js: ^14.7.1
   dotenv: ^16.0.3
   eslint: ^8.34.0
+  husky: ^8.0.3
   moment: ^2.29.4
   pino-pretty: ^9.4.0
   pretty-ms: ^8.0.0
@@ -45,6 +46,7 @@ devDependencies:
   '@typescript-eslint/eslint-plugin': 5.53.0_ny4s7qc6yg74faf3d6xty2ofzy
   '@typescript-eslint/parser': 5.53.0_7kw3g6rralp5ps6mg3uyzz6azm
   eslint: 8.34.0
+  husky: 8.0.3
   rimraf: 4.4.0
   typescript: 4.9.5
 
@@ -1079,6 +1081,12 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: false
+
+  /husky/8.0.3:
+    resolution: {integrity: sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==}
+    engines: {node: '>=14'}
+    hasBin: true
+    dev: true
 
   /ieee754/1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}


### PR DESCRIPTION
eslint will automatically run before commit, to make sure everyone don't forget it before creating pull requests